### PR TITLE
Types: Add DateTime support.

### DIFF
--- a/src/oatpp-mongo/bson/Types.cpp
+++ b/src/oatpp-mongo/bson/Types.cpp
@@ -32,6 +32,7 @@ namespace __class {
   const ClassId InlineDocument::CLASS_ID("oatpp::mongo::InlineDocument");
   const ClassId InlineArray::CLASS_ID("oatpp::mongo::InlineArray");
   const ClassId ObjectId::CLASS_ID("oatpp::mongo::ObjectId");
+  const ClassId DateTime::CLASS_ID("oatpp::mongo::DateTime");
 
 }
 

--- a/src/oatpp-mongo/bson/Types.hpp
+++ b/src/oatpp-mongo/bson/Types.hpp
@@ -187,6 +187,17 @@ namespace __class {
 
   };
 
+  class DateTime {
+  public:
+    static const ClassId CLASS_ID;
+
+    static Type *getType() {
+      static Type type(CLASS_ID, nullptr);
+      return &type;
+    }
+
+  };
+
 }
 
 /**
@@ -205,6 +216,11 @@ typedef oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __clas
  * ObjectId as oatpp primitive type.
  */
 typedef oatpp::data::mapping::type::Primitive<type::ObjectId, __class::ObjectId> ObjectId;
+
+/**
+ * DateTime is an ObjectWrapper over `v_int64` and __class::DateTime.
+ */
+typedef oatpp::data::mapping::type::Primitive<v_int64, __class::DateTime> DateTime;
 
 }}}
 

--- a/src/oatpp-mongo/bson/mapping/Deserializer.cpp
+++ b/src/oatpp-mongo/bson/mapping/Deserializer.cpp
@@ -74,6 +74,8 @@ Deserializer::Deserializer(const std::shared_ptr<Config>& config)
 
   setDeserializerMethod(oatpp::mongo::bson::__class::ObjectId::CLASS_ID, &Deserializer::deserializeObjectId);
 
+  setDeserializerMethod(oatpp::mongo::bson::__class::DateTime::CLASS_ID, &Deserializer::deserializeDateTime);
+
 }
 
 void Deserializer::setDeserializerMethod(const data::mapping::type::ClassId& classId, DeserializerMethod method) {
@@ -197,6 +199,29 @@ oatpp::Void Deserializer::deserializeBoolean(Deserializer* deserializer,
 
   }
 
+}
+
+oatpp::Void Deserializer::deserializeDateTime(Deserializer* deserializer,
+                                              parser::Caret& caret,
+                                              const Type* const type,
+                                              v_char8 bsonTypeCode)
+{
+  (void) deserializer;
+  (void) type;
+
+  switch(bsonTypeCode) {
+
+    case TypeCode::NULL_VALUE:
+      return oatpp::Void(DateTime::Class::getType());
+
+    case TypeCode::DATE_TIME:
+      return DateTime(Utils::readInt64(caret));
+
+    default:
+      caret.setError("[oatpp::mongo::bson::mapping::Deserializer::deserializeDateTime()]: Error. Type-code doesn't match DateTime.");
+      return oatpp::Void(DateTime::Class::getType());
+
+  }
 }
 
 oatpp::Void Deserializer::deserializeString(Deserializer* deserializer,

--- a/src/oatpp-mongo/bson/mapping/Deserializer.hpp
+++ b/src/oatpp-mongo/bson/mapping/Deserializer.hpp
@@ -268,6 +268,7 @@ private:
   }
 
   static oatpp::Void deserializeBoolean(Deserializer* deserializer, parser::Caret& caret, const Type* const type, v_char8 bsonTypeCode);
+  static oatpp::Void deserializeDateTime(Deserializer* deserializer, parser::Caret& caret, const Type* const type, v_char8 bsonTypeCode);
   static oatpp::Void deserializeString(Deserializer* deserializer, parser::Caret& caret, const Type* const type, v_char8 bsonTypeCode);
 
   static oatpp::Void deserializeInlineDocs(Deserializer* deserializer, parser::Caret& caret, const Type* const type, v_char8 bsonTypeCode);

--- a/src/oatpp-mongo/bson/mapping/Serializer.cpp
+++ b/src/oatpp-mongo/bson/mapping/Serializer.cpp
@@ -75,6 +75,8 @@ Serializer::Serializer(const std::shared_ptr<Config>& config)
 
   setSerializerMethod(oatpp::mongo::bson::__class::ObjectId::CLASS_ID, &Serializer::serializeObjectId);
 
+  setSerializerMethod(oatpp::mongo::bson::__class::DateTime::CLASS_ID, &Serializer::serializeDateTime);
+
 }
 
 void Serializer::setSerializerMethod(const data::mapping::type::ClassId& classId, SerializerMethod method) {
@@ -83,6 +85,25 @@ void Serializer::setSerializerMethod(const data::mapping::type::ClassId& classId
     m_methods[id] = method;
   } else {
     throw std::runtime_error("[oatpp::mongo::bson::mapping::Serializer::setSerializerMethod()]: Error. Unknown classId");
+  }
+}
+
+void Serializer::serializeDateTime(Serializer* serializer,
+                                   data::stream::ConsistentOutputStream* stream,
+                                   const data::share::StringKeyLabel& key,
+                                   const oatpp::Void& polymorph)
+{
+  (void) serializer;
+
+  if(!key) {
+    throw std::runtime_error("[oatpp::mongo::bson::mapping::Serializer::serializeDateTime()]: Error. The key can't be null.");
+  }
+
+  if(polymorph) {
+    bson::Utils::writeKey(stream, TypeCode::DATE_TIME, key);
+    bson::Utils::writeInt64(stream, *static_cast<v_int64*>(polymorph.get()));
+  } else {
+    bson::Utils::writeKey(stream, TypeCode::NULL_VALUE, key);
   }
 }
 

--- a/src/oatpp-mongo/bson/mapping/Serializer.hpp
+++ b/src/oatpp-mongo/bson/mapping/Serializer.hpp
@@ -104,7 +104,6 @@ private:
     }
 
     if(polymorph) {
-      auto str = static_cast<oatpp::base::StrBuffer *>(polymorph.get());
       bson::Utils::writePrimitive(stream, key, * static_cast<typename T::ObjectType*>(polymorph.get()));
     } else {
       bson::Utils::writeKey(stream, TypeCode::NULL_VALUE, key);
@@ -180,6 +179,11 @@ private:
     }
 
   }
+
+  static void serializeDateTime(Serializer* serializer,
+                                data::stream::ConsistentOutputStream* stream,
+                                const data::share::StringKeyLabel& key,
+                                const oatpp::Void& polymorph);
 
   static void serializeString(Serializer* serializer,
                               data::stream::ConsistentOutputStream* stream,


### PR DESCRIPTION
Now BSON DateTime data type is supported. 

```cpp
  #include "oatpp-mongo/bson/Types.hpp"

  ...

  auto duration = std::chrono::system_clock::now().time_since_epoch();
  auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();

  collection.insert_one(createMongoDocument(
    oatpp::Fields<oatpp::Any>({
        {"time", oatpp::mongo::bson::DateTime(millis)}
    })
  ));
```

Inserted document:

```json
_id: ObjectId("5f9b6ecb21a7da049662e7d2")
time: 2020-10-30T01:39:23.940+00:00
```

Links:
- https://github.com/oatpp/oatpp/issues/332